### PR TITLE
Add update ticket functionality

### DIFF
--- a/CQRS.Practico/Controllers/TicketsController.cs
+++ b/CQRS.Practico/Controllers/TicketsController.cs
@@ -1,6 +1,11 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using MyApp.Application.Interfaces;
-using MyApp.Application.Queries;
+using MyApp.Application.Interfaces; // Contains UpdateTicketCommand, ICommandHandler
+using MyApp.Application.Queries;  // Contains TicketDto, GetAllTicketsQuery, GetTicketByIdQuery
+// KeyNotFoundException is in System.Collections.Generic, which might be implicitly covered
+// or sometimes requires an explicit 'using System.Collections.Generic;'
+// For Exception, 'using System;' is usually present or implicitly available.
+using System; // For Exception
+using System.Collections.Generic; // For KeyNotFoundException, IEnumerable
 
 namespace CQRS.Practico.Controllers
 {
@@ -11,15 +16,18 @@ namespace CQRS.Practico.Controllers
         private readonly IQueryHandler<GetAllTicketsQuery, IEnumerable<TicketDto>> _queryHandler;
         private readonly IQueryHandler<GetTicketByIdQuery, TicketDto> _getTicketByIdqueryHandler;
         private readonly ICommandHandler<CreateTicketCommand> _commandHandler;
+        private readonly ICommandHandler<UpdateTicketCommand> _updateCommandHandler;
 
         public TicketsController(
             IQueryHandler<GetAllTicketsQuery, IEnumerable<TicketDto>> queryHandler,
             ICommandHandler<CreateTicketCommand> commandHandler,
-            IQueryHandler<GetTicketByIdQuery, TicketDto> getTicketByIdqueryHandler)
+            IQueryHandler<GetTicketByIdQuery, TicketDto> getTicketByIdqueryHandler,
+            ICommandHandler<UpdateTicketCommand> updateCommandHandler)
         {
             _queryHandler = queryHandler;
             _commandHandler = commandHandler;
             _getTicketByIdqueryHandler = getTicketByIdqueryHandler;
+            _updateCommandHandler = updateCommandHandler;
         }
         //Get all tickets
         [HttpGet]
@@ -45,6 +53,36 @@ namespace CQRS.Practico.Controllers
 
             await _commandHandler.HandleAsync(command);
             return NoContent();
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateTicketCommand command)
+        {
+            if (id != command.Id)
+            {
+                return BadRequest("ID mismatch");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                await _updateCommandHandler.HandleAsync(command);
+                return NoContent(); // Or Ok() if you want to return the updated resource
+            }
+            catch (KeyNotFoundException)
+            {
+                return NotFound();
+            }
+            catch (Exception ex)
+            {
+                // Log the exception (implementation of logging is out of scope for this task)
+                // For example: _logger.LogError(ex, "Error updating ticket {TicketId}", command.Id);
+                return StatusCode(500, "An error occurred while updating the ticket.");
+            }
         }
     }
 }

--- a/MyApp.Application/Commands/UpdateTicketHandler.cs
+++ b/MyApp.Application/Commands/UpdateTicketHandler.cs
@@ -1,0 +1,47 @@
+using MyApp.Application.Interfaces; // For UpdateTicketCommand, ICommandHandler, IUnitOfWork
+using MyApp.Domain.Entities;      // For Ticket
+using MyApp.Domain.Interfaces;    // For ITicketRepository (though accessed via IUnitOfWork)
+using System;                     // For ArgumentNullException
+using System.Collections.Generic; // For KeyNotFoundException
+using System.Threading;           // For CancellationToken (if it were used)
+using System.Threading.Tasks;     // For Task
+
+namespace MyApp.Application.Commands
+{
+    public class UpdateTicketHandler : ICommandHandler<UpdateTicketCommand>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public UpdateTicketHandler(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        }
+
+        public async Task HandleAsync(UpdateTicketCommand command)
+        {
+            // Consider adding CancellationToken to ICommandHandler and HandleAsync signature
+            // public async Task HandleAsync(UpdateTicketCommand command, CancellationToken cancellationToken)
+
+            var ticket = await _unitOfWork.TicketRepository.GetTicketByIdAsync(command.Id);
+
+            if (ticket == null)
+            {
+                throw new KeyNotFoundException($"Ticket with Id {command.Id} not found.");
+            }
+
+            // Update ticket properties.
+            // This is now possible because Ticket.cs has public setters for these properties.
+            ticket.NombreTicket = command.NombreTicket;
+            ticket.DesignTicket = command.DesignTicket;
+            ticket.Timbrado = command.Timbrado;
+
+            // Call the repository's Update method.
+            // This method still needs to be defined in ITicketRepository and implemented.
+            _unitOfWork.TicketRepository.Update(ticket);
+
+            // Persist changes to the database.
+            // await _unitOfWork.SaveChangesAsync(cancellationToken); // If CancellationToken were used
+            await _unitOfWork.SaveChangesAsync();
+        }
+    }
+}

--- a/MyApp.Application/Interfaces/ICommand.cs
+++ b/MyApp.Application/Interfaces/ICommand.cs
@@ -1,0 +1,8 @@
+namespace MyApp.Application.Interfaces
+{
+    public interface ICommand
+    {
+        // This can be a marker interface, or it can define common command properties/methods.
+        // For now, keeping it as a marker interface.
+    }
+}

--- a/MyApp.Application/Interfaces/UpdateTicketCommand.cs
+++ b/MyApp.Application/Interfaces/UpdateTicketCommand.cs
@@ -1,0 +1,14 @@
+namespace MyApp.Application.Interfaces
+{
+    // No explicit using needed for ICommand as it's in the same namespace.
+    // If ICommand were in a different namespace, e.g., MyApp.Application.Core,
+    // then 'using MyApp.Application.Core;' would be required.
+
+    public class UpdateTicketCommand : ICommand
+    {
+        public int Id { get; set; } // Corresponds to Ticket.Codigo
+        public string NombreTicket { get; set; } // Corresponds to Ticket.NombreTicket
+        public string DesignTicket { get; set; } // Corresponds to Ticket.DesignTicket
+        public bool Timbrado { get; set; } // Corresponds to Ticket.Timbrado
+    }
+}

--- a/MyApp.Application/Validators/UpdateTicketCommandValidator.cs
+++ b/MyApp.Application/Validators/UpdateTicketCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using MyApp.Application.Interfaces; // This references the namespace where UpdateTicketCommand is defined
+
+namespace MyApp.Application.Validators
+{
+    public class UpdateTicketCommandValidator : AbstractValidator<UpdateTicketCommand>
+    {
+        public UpdateTicketCommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage("Id must be greater than 0.");
+
+            RuleFor(x => x.NombreTicket)
+                .NotEmpty().WithMessage("NombreTicket must not be empty.")
+                .MaximumLength(100).WithMessage("NombreTicket must not exceed 100 characters.");
+
+            RuleFor(x => x.DesignTicket)
+                .NotEmpty().WithMessage("DesignTicket must not be empty.");
+
+            // For boolean properties like Timbrado, NotNull can be used if the property is nullable,
+            // but since bool is a value type and defaults to false,
+            // specific validation (e.g., MustBeTrue or MustBeFalse) is only needed if 'false' is an invalid state.
+            // The requirement "Timbrado must be a boolean value" is inherently met by its type.
+            // No explicit rule is added for Timbrado itself unless specific true/false validation is needed.
+        }
+    }
+}

--- a/MyApp.Domain/Entities/Ticket.cs
+++ b/MyApp.Domain/Entities/Ticket.cs
@@ -8,9 +8,9 @@ namespace MyApp.Domain.Entities
     public class Ticket
     {
         public int Codigo { get; private set; }
-        public string NombreTicket { get; private set; }
-        public string DesignTicket { get; private set; }
-        public bool Timbrado { get; private set; }
+        public string NombreTicket { get; set; }
+        public string DesignTicket { get; set; }
+        public bool Timbrado { get; set; }
 
         private Ticket() { }
 

--- a/MyApp.Domain/Interfaces/ITicketRepository.cs
+++ b/MyApp.Domain/Interfaces/ITicketRepository.cs
@@ -7,5 +7,6 @@ namespace MyApp.Domain.Interfaces
         Task<List<Ticket>> GetAllAsync();
         void Add(Ticket ticket);
         Task<Ticket> GetTicketByIdAsync(int codigo);
+        void Update(Ticket ticket);
     }
 }

--- a/MyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
+++ b/MyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
@@ -5,6 +5,10 @@ using MyApp.Application.Interfaces;
 using MyApp.Domain.Interfaces;
 using MyApp.Infrastructure.Context;
 using MyApp.Infrastructure.Repositories;
+using MyApp.Application.Interfaces; // For ICommandHandler, UpdateTicketCommand (as generic arg)
+using MyApp.Application.Commands;   // For UpdateTicketHandler
+using MyApp.Application.Validators; // For UpdateTicketCommandValidator
+using FluentValidation;             // For IValidator
 
 namespace MyApp.Infrastructure
 {
@@ -18,7 +22,20 @@ namespace MyApp.Infrastructure
             services.AddScoped<ITicketRepository, TicketRepository>();
             services.AddScoped<IProductRepository, ProductRepository>();
             services.AddScoped<ISaleRepository, SaleRepository>();
-            services.AddScoped<IUnitOfWork, UnitOfWork>();
+            services.AddScoped<IUnitOfWork, UnitOfWork>(); // UnitOfWork is part of Infrastructure in this setup
+            return services;
+        }
+
+        public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+        {
+            // Register Validators
+            services.AddTransient<IValidator<UpdateTicketCommand>, UpdateTicketCommandValidator>();
+
+            // Register Command Handlers
+            services.AddTransient<ICommandHandler<UpdateTicketCommand>, UpdateTicketHandler>();
+
+            // Add other application services registrations here if any
+
             return services;
         }
     }

--- a/MyApp.Infrastructure/Repositories/TicketRepository.cs
+++ b/MyApp.Infrastructure/Repositories/TicketRepository.cs
@@ -27,5 +27,10 @@ namespace MyApp.Infrastructure.Repositories
         {
             _context.Tickets.Add(ticket);
         }
+
+        public void Update(Ticket ticket)
+        {
+            _context.Tickets.Update(ticket);
+        }
     }
 }


### PR DESCRIPTION
This commit introduces the capability to update existing tickets.

The following changes were made:
- Modified the `Ticket` entity in `MyApp.Domain` to allow its properties to be updated by changing setters from private to public for `NombreTicket`, `DesignTicket`, and `Timbrado`.
- Defined `UpdateTicketCommand` in `MyApp.Application/Interfaces` to carry data for ticket updates and implemented a new `ICommand` marker interface.
- Created `UpdateTicketCommandValidator` in `MyApp.Application/Validators` using FluentValidation to validate incoming update requests.
- Implemented `UpdateTicketHandler` in `MyApp.Application/Commands` to handle the logic of fetching, updating, and saving tickets.
- Added an `Update` method to the `ITicketRepository` interface and its corresponding implementation in `TicketRepository.cs`.
- Added a new HTTP PUT endpoint `api/Tickets/{id}` in `TicketsController.cs` to expose the update functionality.
- Registered the new `UpdateTicketHandler` and `UpdateTicketCommandValidator` in `MyApp.Infrastructure/DependencyInjections/DependencyInjection.cs` for dependency injection.