### PR TITLE
Add endpoint to get timbrado tickets

### DIFF
--- a/CQRS.Practico/Controllers/TicketsController.cs
+++ b/CQRS.Practico/Controllers/TicketsController.cs
@@ -118,7 +118,7 @@ namespace CQRS.Practico.Controllers
             }
         }
 
-        [HttpGet("timbrado")]
+        [HttpGet("Timbrado")]
         public async Task<IActionResult> GetTimbradoTickets()
         {
             var result = await _getTimbradoTicketsQueryHandler.HandleAsync(new GetTimbradoTicketsQuery(true));

--- a/CQRS.Practico/Controllers/TicketsController.cs
+++ b/CQRS.Practico/Controllers/TicketsController.cs
@@ -18,19 +18,22 @@ namespace CQRS.Practico.Controllers
         private readonly ICommandHandler<CreateTicketCommand> _commandHandler;
         private readonly ICommandHandler<UpdateTicketCommand> _updateCommandHandler;
         private readonly ICommandHandler<DeleteTicketCommand> _deleteCommandHandler; // Added
+        private readonly IQueryHandler<GetTimbradoTicketsQuery, IEnumerable<TicketDto>> _getTimbradoTicketsQueryHandler;
 
         public TicketsController(
             IQueryHandler<GetAllTicketsQuery, IEnumerable<TicketDto>> queryHandler,
             ICommandHandler<CreateTicketCommand> commandHandler,
             IQueryHandler<GetTicketByIdQuery, TicketDto> getTicketByIdqueryHandler,
             ICommandHandler<UpdateTicketCommand> updateCommandHandler,
-            ICommandHandler<DeleteTicketCommand> deleteCommandHandler) // Added
+            ICommandHandler<DeleteTicketCommand> deleteCommandHandler, // Added
+            IQueryHandler<GetTimbradoTicketsQuery, IEnumerable<TicketDto>> getTimbradoTicketsQueryHandler)
         {
             _queryHandler = queryHandler;
             _commandHandler = commandHandler;
             _getTicketByIdqueryHandler = getTicketByIdqueryHandler;
             _updateCommandHandler = updateCommandHandler;
             _deleteCommandHandler = deleteCommandHandler; // Added
+            _getTimbradoTicketsQueryHandler = getTimbradoTicketsQueryHandler;
         }
 
         [HttpGet]
@@ -113,6 +116,13 @@ namespace CQRS.Practico.Controllers
                 // Log the exception (e.g., _logger.LogError(ex, "Error deleting ticket {TicketId}", id);)
                 return StatusCode(500, $"An error occurred while deleting the ticket with ID {id}.");
             }
+        }
+
+        [HttpGet("timbrado")]
+        public async Task<IActionResult> GetTimbradoTickets()
+        {
+            var result = await _getTimbradoTicketsQueryHandler.HandleAsync(new GetTimbradoTicketsQuery(true));
+            return Ok(result);
         }
     }
 }

--- a/MyApp.Application/Interfaces/GetTimbradoTicketsQuery.cs
+++ b/MyApp.Application/Interfaces/GetTimbradoTicketsQuery.cs
@@ -1,0 +1,12 @@
+namespace MyApp.Application.Interfaces
+{
+    public class GetTimbradoTicketsQuery
+    {
+        public bool Timbrado { get; }
+
+        public GetTimbradoTicketsQuery(bool timbrado)
+        {
+            Timbrado = timbrado;
+        }
+    }
+}

--- a/MyApp.Application/Queries/GetTimbradoTicketsHandler.cs
+++ b/MyApp.Application/Queries/GetTimbradoTicketsHandler.cs
@@ -1,0 +1,24 @@
+using MyApp.Application.Interfaces;
+using MyApp.Domain.Entities; // Required for Ticket
+using System.Collections.Generic; // Required for IEnumerable
+using System.Linq; // Required for Select
+using System.Threading.Tasks; // Required for Task
+
+namespace MyApp.Application.Queries
+{
+    public class GetTimbradoTicketsHandler : IQueryHandler<GetTimbradoTicketsQuery, IEnumerable<TicketDto>>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+
+        public GetTimbradoTicketsHandler(IUnitOfWork unitOfWork)
+        {
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<IEnumerable<TicketDto>> HandleAsync(GetTimbradoTicketsQuery query)
+        {
+            var tickets = await _unitOfWork.TicketRepository.GetTicketsByTimbradoAsync(query.Timbrado);
+            return tickets.Select(t => new TicketDto(t.Codigo, t.NombreTicket));
+        }
+    }
+}

--- a/MyApp.Domain/Interfaces/ITicketRepository.cs
+++ b/MyApp.Domain/Interfaces/ITicketRepository.cs
@@ -9,5 +9,6 @@ namespace MyApp.Domain.Interfaces
         Task<Ticket> GetTicketByIdAsync(int codigo);
         void Update(Ticket ticket);
         Task DeleteTicket(int id); // New method
+        Task<List<Ticket>> GetTicketsByTimbradoAsync(bool timbrado);
     }
 }

--- a/MyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
+++ b/MyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
@@ -34,12 +34,14 @@ namespace MyApp.Infrastructure.DependencyInjections
             // Register Query Handlers
             services.AddScoped<IQueryHandler<GetAllTicketsQuery, IEnumerable<TicketDto>>, GetAllTicketsHandler>();
             services.AddTransient<IQueryHandler<GetTicketByIdQuery, TicketDto>, GetTicketByIdHandler>();
+            services.AddTransient<IQueryHandler<GetTimbradoTicketsQuery, IEnumerable<TicketDto>>, GetTimbradoTicketsHandler>();
 
             // Register Command Handlers
             services.AddScoped<ICommandHandler<CreateTicketCommand>, CreateTicketHandler>();
             services.AddTransient<ICommandHandler<UpdateTicketCommand>, UpdateTicketHandler>(); // Kept one Transient registration
             services.AddScoped<ICommandHandler<CreateSaleCommand>, CreateSaleHandler>();
             services.AddTransient<ICommandHandler<DeleteTicketCommand>, DeleteTicketCommandHandler>();
+
 
 
             return services;

--- a/MyApp.Infrastructure/Repositories/TicketRepository.cs
+++ b/MyApp.Infrastructure/Repositories/TicketRepository.cs
@@ -3,6 +3,7 @@ using MyApp.Domain.Entities;
 using MyApp.Domain.Interfaces;
 using MyApp.Infrastructure.Context;
 using System.Collections.Generic; // For KeyNotFoundException
+using System.Linq; // Added for Where()
 using System.Threading.Tasks; // For Task
 
 namespace MyApp.Infrastructure.Repositories
@@ -44,6 +45,11 @@ namespace MyApp.Infrastructure.Repositories
                 throw new KeyNotFoundException($"Ticket with ID {id} not found.");
             }
             _context.Tickets.Remove(ticket);
+        }
+
+        public async Task<List<Ticket>> GetTicketsByTimbradoAsync(bool timbrado)
+        {
+            return await _context.Tickets.Where(t => t.Timbrado == timbrado).ToListAsync();
         }
     }
 }


### PR DESCRIPTION
This commit introduces a new endpoint `GET api/tickets/timbrado` that returns all tickets with the `Timbrado` field set to true.

Changes include:
- Added `GetTicketsByTimbradoAsync` to the ticket repository.
- Created `GetTimbradoTicketsQuery` and `GetTimbradoTicketsHandler` for fetching timbrado tickets.
- Updated `TicketsController` to include the new endpoint.